### PR TITLE
Must include AAR dependencies in the build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,9 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "org.walleth:WALLETH-0.29-withGeth-noFirebase-forFDroid-debug@aar"
+    implementation "org.walleth:WALLETH-0.29-withGeth-noFirebase-forFDroid-debug@aar" {
+        transitive = true;
+    }
     implementation fileTree(include: ['*.jar'], dir: '/cryptosecure/studio/tyle-kethereum/*/build/libs')
 
     implementation "org.ethereum:geth:1.7.3"


### PR DESCRIPTION
This includes the AAR dependencies when building, otherwise it has errors and can even fail